### PR TITLE
sm8150-common: Add OOSCamera support

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,4 +1,5 @@
 soong_namespace {
+    imports: ["device/oneplus/common"],
 }
 
 prebuilt_hidl_interfaces {

--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -60,6 +60,9 @@ AB_OTA_PARTITIONS += \
     vbmeta_system
 endif
 
+# Camera
+TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB := true
+
 # FOD
 TARGET_USES_FOD_ZPOS := true
 TARGET_SURFACEFLINGER_UDFPS_LIB := //device/oneplus/common:libudfps_extension.oneplus

--- a/DeviceSettings/Android.bp
+++ b/DeviceSettings/Android.bp
@@ -11,6 +11,7 @@ android_app {
         "androidx.core_core-ktx",
         "androidx.preference_preference",
         "androidx.fragment_fragment-ktx",
+        "vendor.oneplus.hardware.camera-V1.0-java",
         "vendor_support",
     ],
     required: [

--- a/DeviceSettings/AndroidManifest.xml
+++ b/DeviceSettings/AndroidManifest.xml
@@ -67,9 +67,13 @@
             android:name=".BootCompletedReceiver"
             android:exported="false">
             <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 
+        <service
+            android:name=".ClientPackageObserverService"
+            android:exported="false" />
     </application>
 </manifest>

--- a/DeviceSettings/src/com/flamingo/settings/device/BootCompletedReceiver.kt
+++ b/DeviceSettings/src/com/flamingo/settings/device/BootCompletedReceiver.kt
@@ -20,6 +20,7 @@ package com.flamingo.settings.device
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.UserHandle
 import android.provider.Settings
 
 import androidx.annotation.Keep
@@ -44,6 +45,14 @@ class BootCompletedReceiver : BroadcastReceiver() {
                     context.contentResolver, getResName(gesture.name), 0)
                 hardwareManager.setTouchscreenGestureEnabled(gesture, actionForGesture > 0)
             }
+        } else if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            context.startServiceAsUser(
+                Intent(
+                    context,
+                    ClientPackageObserverService::class.java
+                ),
+                UserHandle.SYSTEM
+            )
         }
     }
 

--- a/DeviceSettings/src/com/flamingo/settings/device/ClientPackageObserverService.kt
+++ b/DeviceSettings/src/com/flamingo/settings/device/ClientPackageObserverService.kt
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2022 FlamingoOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flamingo.settings.device
+
+import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_SCREEN_OFF
+import android.content.Intent.ACTION_SCREEN_ON
+import android.content.IntentFilter
+import android.os.FileObserver
+import android.os.IBinder
+import android.os.RemoteException
+import android.util.Log
+
+import com.android.internal.util.flamingo.FileUtils
+import com.android.internal.util.flamingo.FlamingoUtils
+
+import java.io.File
+
+import vendor.oneplus.hardware.camera.V1_0.IOnePlusCameraProvider
+
+class ClientPackageObserverService : Service() {
+
+    private var isOpCameraInstalledAndActive = false
+    private var clientObserverRegistered = false
+
+    private val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent?) {
+            when (intent?.action) {
+                ACTION_SCREEN_OFF -> unregisterClientObserver()
+                ACTION_SCREEN_ON -> registerClientObserver()
+            }
+        }
+    }
+
+    private val fileObserver = object : FileObserver(File(CLIENT_PACKAGE_PATH)) {
+        override fun onEvent(event: Int , file: String) {
+            setPackageName(file)
+        }
+    }
+
+    private var receiverRegistered = false
+
+    override fun onCreate() {
+        super.onCreate()
+        logD("onCreate")
+        isOpCameraInstalledAndActive = FlamingoUtils.isPackageInstalled(this,
+            CLIENT_PACKAGE_NAME, false /** ignore state */)
+        logD("isOpCameraInstalledAndActive = $isOpCameraInstalledAndActive")
+        if (isOpCameraInstalledAndActive) {
+            setPackageName(CLIENT_PACKAGE_PATH)
+        } else {
+            stopSelf()
+            return
+        }
+        registerReceiver(broadcastReceiver, IntentFilter().apply {
+            addAction(ACTION_SCREEN_OFF)
+            addAction(ACTION_SCREEN_ON)
+        })
+        registerClientObserver()
+        receiverRegistered = true
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        if (receiverRegistered) {
+            unregisterReceiver(broadcastReceiver)
+        }
+        unregisterClientObserver()
+    }
+
+    private fun registerClientObserver() {
+        isOpCameraInstalledAndActive = FlamingoUtils.isPackageInstalled(this,
+            CLIENT_PACKAGE_NAME, false /** ignore state */)
+        if (isOpCameraInstalledAndActive && !clientObserverRegistered) {
+            logD("registering client observer")
+            fileObserver.startWatching()
+            clientObserverRegistered = true
+        }
+    }
+
+    private fun unregisterClientObserver() {
+        if (clientObserverRegistered) {
+            logD("unregistering client observer")
+            fileObserver.stopWatching()
+            clientObserverRegistered = false
+        }
+    }
+
+    private fun setPackageName(file: String) {
+        val pkgName: String? = FileUtils.readOneLine(file) ?: CLIENT_PACKAGE_NAME
+        try {
+            logD("client_package $file and pkg = $pkgName")
+            IOnePlusCameraProvider.getService()?.setPackageName(pkgName)
+        } catch (e: RemoteException) {
+            Log.e(TAG, "Error communicating with IOnePlusCameraProvider")
+        }
+    }
+
+    private fun logD(msg: String) {
+        if (DEBUG) Log.d(TAG, msg)
+    }
+
+    companion object {
+        private const val CLIENT_PACKAGE_NAME = "com.oneplus.camera"
+        private const val CLIENT_PACKAGE_PATH = "/data/misc/aosp/client_package_name"
+
+        private const val TAG = "ClientPackageObserverService"
+        private const val DEBUG = false
+    }
+}

--- a/common.mk
+++ b/common.mk
@@ -143,11 +143,22 @@ PRODUCT_PACKAGES += \
     vendor.qti.hardware.camera.device@1.0.vendor:64
 
 PRODUCT_VENDOR_PROPERTIES += \
+    vendor.product.manufacturer=OPD \
     ro.vendor.camera.res.fmq.size=1048576
 
+PRODUCT_PRODUCT_PROPERTIES += \
+    ro.com.google.lens.oem_camera_package=com.oneplus.camera
+
+PRODUCT_SYSTEM_PROPERTIES += \
+    persist.camera.assert.panic=true \
+    persist.camera.privapp.list=com.oneplus.factorymode,com.oneplus.camera,com.oem.autotest,com.oneplus.healthcheck \
+    ro.opcamera.support=true \
+    ro.vendor.product.manufacturer.db=OP_PHONE \
+    ro.vendor.product.device.db=OP_DEVICE
+
 PRODUCT_SYSTEM_EXT_PROPERTIES += \
-    persist.vendor.camera.privapp.list=com.oneplus.camera \
-    vendor.camera.aux.packagelist=org.codeaurora.snapcam,com.oneplus.camera
+    persist.vendor.camera.privapp.list=com.oneplus.factorymode,com.oneplus.camera,com.oem.autotest,com.oneplus.healthcheck \
+    vendor.camera.aux.packagelist=org.codeaurora.snapcam,com.oneplus.factorymode,com.oneplus.camera
 
 # Charger
 PRODUCT_SYSTEM_EXT_PROPERTIES += \
@@ -157,6 +168,7 @@ PRODUCT_SYSTEM_EXT_PROPERTIES += \
 PRODUCT_PACKAGES += \
     init.class_main.sh \
     init.oem.rc \
+    init.opcamera.rc \
     init.oneplus.usb.rc \
     init.qcom.class_core.sh \
     init.qcom.early_boot.sh \
@@ -266,6 +278,11 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_VENDOR_PROPERTIES += \
     ro.camera.notify_nfc=1
+
+# OnePlus Apps
+PRODUCT_PACKAGES += \
+    OnePlusCameraOverlay \
+    OnePlusGalleryOverlay
 
 # Platform
 TARGET_BOARD_PLATFORM := msmnile

--- a/extract-utils/proprietary-files.txt
+++ b/extract-utils/proprietary-files.txt
@@ -78,12 +78,42 @@ vendor/lib64/vendor.qti.hardware.bluetooth_sar@1.0.so
 vendor/lib64/vendor.qti.hardware.bluetooth_sar@1.1.so
 
 # Camera
+system_ext/lib64/libCameraMDMHelper.so
+system_ext/lib64/vendor.oneplus.hardware.camera@1.0.so
+system_ext/lib64/vendor.oneplus.hardware.camera@1.0-adapter-helper.so
+system_ext/lib64/vendor.oneplus.hardware.CameraMDMHIDL@1.0.so
+system_ext/lib64/vendor.oneplus.hardware.CameraMDMHIDL@1.0-adapter-helper.so
+vendor/bin/hw/android.hardware.camera.provider@2.4-service_64
 vendor/bin/hw/vendor.oneplus.hardware.camera@1.0-service
 vendor/bin/hw/vendor.oneplus.hardware.CameraMDMHIDL@1.0-service
 vendor/bin/vl53l1_daemon_main
+vendor/etc/init/android.hardware.camera.provider@2.4-service_64.rc
 vendor/etc/init/vendor.oneplus.hardware.camera@1.0-service.rc
 vendor/etc/init/vendor.oneplus.hardware.CameraMDMHIDL@1.0-service.rc
 vendor/etc/init/vl53l1.rc
+vendor/lib/hw/android.hardware.camera.provider@2.4-impl.so
+vendor/lib/android.hardware.camera.provider@2.4-external.so
+vendor/lib/android.hardware.camera.provider@2.4-legacy.so
+vendor/lib/camera.device@1.0-impl.so
+vendor/lib/camera.device@3.2-impl.so
+vendor/lib/camera.device@3.3-impl.so
+vendor/lib/camera.device@3.4-external-impl.so
+vendor/lib/camera.device@3.4-impl.so
+vendor/lib/camera.device@3.5-external-impl.so
+vendor/lib/camera.device@3.5-impl.so
+vendor/lib/camera.device@3.6-external-impl.so
+vendor/lib/vendor.qti.hardware.camera.device@1.0.so
+vendor/lib64/hw/android.hardware.camera.provider@2.4-impl.so
+vendor/lib64/android.hardware.camera.provider@2.4-external.so
+vendor/lib64/android.hardware.camera.provider@2.4-legacy.so
+vendor/lib64/camera.device@1.0-impl.so
+vendor/lib64/camera.device@3.2-impl.so
+vendor/lib64/camera.device@3.3-impl.so
+vendor/lib64/camera.device@3.4-external-impl.so
+vendor/lib64/camera.device@3.4-impl.so
+vendor/lib64/camera.device@3.5-external-impl.so
+vendor/lib64/camera.device@3.5-impl.so
+vendor/lib64/camera.device@3.6-external-impl.so
 vendor/lib64/lib_bokehlib.so
 vendor/lib64/lib_oneplus_watermark.so
 vendor/lib64/libarcsoft_beautyshot.so
@@ -135,6 +165,7 @@ vendor/lib64/libvidhance.so
 vendor/lib64/libvl53l1_daemon.so
 vendor/lib64/sensors.hal.tof.so
 vendor/lib64/vendor.oneplus.hardware.CameraMDMHIDL@1.0.so
+vendor/lib64/vendor.qti.hardware.camera.device@1.0.so
 
 # Camera firmware
 vendor/firmware/CAMERA_ICP.elf

--- a/init/Android.bp
+++ b/init/Android.bp
@@ -21,6 +21,12 @@ sh_binary {
 }
 
 sh_binary {
+    name: "init.opcamera.rc",
+    src: "etc/init.opcamera.rc",
+    vendor: true,
+}
+
+sh_binary {
     name: "init.qcom.class_core.sh",
     src: "bin/init.qcom.class_core.sh",
     vendor: true,

--- a/init/etc/init.opcamera.rc
+++ b/init/etc/init.opcamera.rc
@@ -1,0 +1,5 @@
+on boot
+    mkdir /data/misc/aosp/ 0774 cameraserver audio
+    write /data/misc/aosp/client_package_name 0
+    chown cameraserver audio /data/misc/aosp/client_package_name
+    chmod 0644 /data/misc/aosp/client_package_name

--- a/overlay/OnePlusCameraOverlay/Android.bp
+++ b/overlay/OnePlusCameraOverlay/Android.bp
@@ -1,0 +1,6 @@
+runtime_resource_overlay {
+    name: "OnePlusCameraOverlay",
+    certificate: "platform",
+    sdk_version: "current",
+    system_ext_specific: true
+}

--- a/overlay/OnePlusCameraOverlay/AndroidManifest.xml
+++ b/overlay/OnePlusCameraOverlay/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.oneplus.camera.overlay"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="com.oneplus.camera" android:priority="1" android:isStatic="true" />
+
+    <application android:label="OnePlusCameraOverlay" android:hasCode="false"/>
+</manifest>

--- a/overlay/OnePlusCameraOverlay/res/values/colors.xml
+++ b/overlay/OnePlusCameraOverlay/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <color name="oneplus_accent_color">@*android:color/accent_device_default</color>
+    <color name="oneplus_accent_text_color">@*android:color/accent_device_default</color>
+</resources>

--- a/overlay/OnePlusGalleryOverlay/Android.bp
+++ b/overlay/OnePlusGalleryOverlay/Android.bp
@@ -1,0 +1,6 @@
+runtime_resource_overlay {
+    name: "OnePlusGalleryOverlay",
+    certificate: "platform",
+    sdk_version: "current",
+    system_ext_specific: true
+}

--- a/overlay/OnePlusGalleryOverlay/AndroidManifest.xml
+++ b/overlay/OnePlusGalleryOverlay/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.oneplus.gallery.overlay"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="com.oneplus.gallery" android:priority="1" android:isStatic="true" />
+
+    <application android:label="OnePlusGalleryOverlay" android:hasCode="false"/>
+</manifest>

--- a/overlay/OnePlusGalleryOverlay/res/values/colors.xml
+++ b/overlay/OnePlusGalleryOverlay/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <color name="oneplus_accent_color">@*android:color/accent_device_default</color>
+    <color name="oneplus_accent_text_color">@*android:color/accent_device_default</color>
+</resources>

--- a/sepolicy/private/cameraserver.te
+++ b/sepolicy/private/cameraserver.te
@@ -1,0 +1,2 @@
+allow cameraserver aosp_data_file:dir create_dir_perms;
+allow cameraserver aosp_data_file:file create_file_perms;

--- a/sepolicy/private/file.te
+++ b/sepolicy/private/file.te
@@ -1,0 +1,2 @@
+# Data File
+type aosp_data_file, file_type, data_file_type,  core_data_file_type;

--- a/sepolicy/private/file_contexts
+++ b/sepolicy/private/file_contexts
@@ -1,2 +1,5 @@
 # Binaries
 /system/bin/als_correction_service    u:object_r:als_correction_service_exec:s0
+
+# Data files
+/data/misc/aosp(/.*)?                 u:object_r:aosp_data_file:s0

--- a/sepolicy/private/mediaserver.te
+++ b/sepolicy/private/mediaserver.te
@@ -1,0 +1,1 @@
+dontaudit mediaserver package_native_service:service_manager { find };

--- a/sepolicy/private/property_contexts
+++ b/sepolicy/private/property_contexts
@@ -1,2 +1,6 @@
 # Sensors
 vendor.sensors.als_correction.    u:object_r:vendor_sensors_als_prop:s0
+
+# Camera
+ro.camera.req.fmq.     u:object_r:exported_default_prop:s0
+ro.camera.res.fmq.     u:object_r:exported_default_prop:s0

--- a/sepolicy/private/system_app.te
+++ b/sepolicy/private/system_app.te
@@ -1,0 +1,2 @@
+allow system_app aosp_data_file:dir r_dir_perms;
+allow system_app aosp_data_file:file r_file_perms;

--- a/sepolicy/vendor/cameraserver.te
+++ b/sepolicy/vendor/cameraserver.te
@@ -1,0 +1,2 @@
+allow cameraserver hal_cameraHIDL_hwservice:hwservice_manager find;
+binder_call(cameraserver, hal_cameraHIDL_default)

--- a/sepolicy/vendor/hal_cameraHIDL_default.te
+++ b/sepolicy/vendor/hal_cameraHIDL_default.te
@@ -3,3 +3,6 @@ hal_server_domain(hal_cameraHIDL_default, hal_cameraHIDL)
 
 type hal_cameraHIDL_default_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(hal_cameraHIDL_default)
+
+allow hal_cameraHIDL_default vendor_camera_data_file:dir create_dir_perms;
+allow hal_cameraHIDL_default vendor_camera_data_file:file create_file_perms;

--- a/sepolicy/vendor/hal_camera_default.te
+++ b/sepolicy/vendor/hal_camera_default.te
@@ -21,4 +21,5 @@ set_prop(hal_camera_default, vendor_camera_prop)
 allow hal_camera_default vendor_xdsp_device:chr_file r_file_perms;
 
 # Allow hal_camera_default to read from input device
-allow hal_camera_default input_device:dir read;
+allow hal_camera_default input_device:dir r_dir_perms;
+allow hal_camera_default input_device:chr_file r_file_perms;

--- a/sepolicy/vendor/platform_app.te
+++ b/sepolicy/vendor/platform_app.te
@@ -1,2 +1,4 @@
 # Allow SystemUI to read measured fps
 allow platform_app vendor_sysfs_graphics:file r_file_perms;
+
+allow platform_app oem_service:service_manager find;

--- a/sepolicy/vendor/priv_app.te
+++ b/sepolicy/vendor/priv_app.te
@@ -1,2 +1,12 @@
 # Allow priv_app to read files in vendor_sysfs_battery_supply
-r_dir_file(priv_app, vendor_sysfs_battery_supply)
+r_dir_file(priv_app, vendor_sysfs_battery_supply) 
+allow priv_app vendor_sysfs_kgsl:file r_file_perms;
+allow priv_app vendor_xdsp_device:chr_file r_file_perms;
+allow priv_app adsprpcd_file:dir r_dir_perms;
+
+allow priv_app hal_cameraHIDL_hwservice:hwservice_manager find;
+binder_call(priv_app, hal_cameraHIDL_default)
+
+
+allow priv_app vendor_sysfs_battery_supply:dir { search };
+allow priv_app vendor_sysfs_battery_supply:file rw_file_perms;

--- a/sepolicy/vendor/property.te
+++ b/sepolicy/vendor/property.te
@@ -1,2 +1,4 @@
 vendor_internal_prop(vendor_nfc_prop)
 vendor_internal_prop(vendor_param_prop)
+# Vendor aware available type
+vendor_public_prop(deviceid_prop)

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -1,11 +1,15 @@
 # Audio
 persist.vendor.audio.hac.enable    u:object_r:vendor_audio_prop:s0
 
+# Aware
+ro.vendor.aware_available          u:object_r:deviceid_prop:s0
+
 # Bluetooth
 persist.vendor.bt.a2dp_offload_cap    u:object_r:bluetooth_a2dp_offload_prop:s0
 
 # Camera
-vendor.camera.        u:object_r:vendor_camera_prop:s0
+vendor.camera.                      u:object_r:vendor_camera_prop:s0
+vendor.oneplus.gallery.debugStory   u:object_r:vendor_camera_prop:s0
 
 # Display
 persist.vendor.color.matrix    u:object_r:vendor_display_prop:s0

--- a/sepolicy/vendor/system_app.te
+++ b/sepolicy/vendor/system_app.te
@@ -1,6 +1,6 @@
 # Allow system_app to access zram sysfs nodes
 allow system_app sysfs_zram:dir { search r_file_perms };
-allow system_app sysfs_oem:file { read write getattr open };
+allow system_app sysfs_oem:file rw_file_perms;
 
 # Allow system_app to read and write to sysfs_aod
 allow system_app sysfs_aod:file rw_file_perms;
@@ -9,8 +9,15 @@ allow system_app sysfs_aod:file rw_file_perms;
 allow system_app sysfs_fod:file rw_file_perms;
 
 # Allow system_app to read, open and get attributes of vendor_sysfs_graphics
-allow system_app vendor_sysfs_graphics:file { getattr open read };
+allow system_app vendor_sysfs_graphics:file r_file_perms;
 
 # Vibrator
 allow system_app sysfs_vibrator:file rw_file_perms;
 allow system_app sysfs_vibrator:dir r_dir_perms;
+
+allow system_app sysfs_leds:dir { search };
+
+allow system_app hal_cameraHIDL_hwservice:hwservice_manager find;
+binder_call(system_app, hal_cameraHIDL_default)
+
+get_prop(system_app, deviceid_prop)

--- a/sepolicy/vendor/system_server.te
+++ b/sepolicy/vendor/system_server.te
@@ -2,3 +2,8 @@ allow system_server { proc_sensor proc_ultrasound proc_touchpanel }:dir search;
 
 # Allow read access to fastcharge sysfs node
 allow system_server vendor_sysfs_battery_supply:file r_file_perms;
+
+allow system_server hal_cameraHIDL_hwservice:hwservice_manager { find };
+binder_call(system_server, hal_cameraHIDL_default)
+
+get_prop(system_server, vendor_camera_prop)

--- a/sepolicy/vendor/vendor_service.te
+++ b/sepolicy/vendor/vendor_service.te
@@ -1,0 +1,1 @@
+type oem_service,           service_manager_type;


### PR DESCRIPTION
Revert "devicesettings: Drop client package"

This reverts commit f843c6b5cf992a41610773c30815db3c667c65ad.

Signed-off-by: Harish <sanganiharish263@gmail.com>

sm8150-common: Add device OnePlus device specific props

Some proprietary blobs like dolby and camera check them

sm8150-common: use TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB

Recently LOS changed KeyHandler to service. Service doesn't use system_server context, so FileObserver of old implementation can't access client info file. This implementation directly writes package name without using any files.

Signed-off-by: Shantanu Sarkar <shantanuplussarkar@gmail.com>

sm8150-common: Build OnePlusCamera and OnePlusGallery

Signed-off-by: Harish <sanganiharish263@gmail.com>

sm8150-common: Switch to prebuilt camera provider

Opensource one not working properly with OnePlusCamera.

sm8150-common: sepolicy: correct few camera denials

sm8150-common: Let oneplus camera have its own domain

* This can separate sepolicy for this specific app.
* Resolve some oneplus camera related denials

sm8150-common: Resolve some camera denials

Also fix denials for some apps

sm8150-common: rro_overlays: Add RRO for OnePlusCamera & OnePlusGallery

Change-Id: I515c929c5c7f2b78ef8f758bb5423afd7cfb7d61

sm8150-common: sepolicy: Label camera fmq prop

* Access denied finding property "ro.camera.req.fmq.size"

* Access denied finding property "ro.camera.res.fmq.size"

Signed-off-by: Zinadin Zidan <zidan.roking@gmail.com>
Change-Id: I3bd237320b452ff143f6f1f62769082249368294

sm8150-common: Add missing camera HAL

Signed-off-by: Harish <sanganiharish263@gmail.com>

sm8150-common: fixup fileobserver and add back some sepolicy rules for opcam

* default to client package name if unable to read from disk

Signed-off-by: jhonboy121 <alfredmathew05@gmail.com>

sm8150-common: Set PROPERTY_OVERRIDES properly

Signed-off-by: Harish <sanganiharish263@gmail.com>

sm8150-common: sepolicy: cleanup and simplify rules

* removed a lot of unnecessary sepolicy
* used macros for some others
* properly labelled aosp_data_file

Signed-off-by: jhonboy121 <alfredmathew05@gmail.com>

sm8150-common: sepolicy: Allow system_app to read aware available prop
*Fix W libc    : Access denied finding property "ro.vendor.aware_available"

Signed-off-by: Harish <sanganiharish263@gmail.com>

sm8150-common: sepolicy: Fix mediaserver Selinux denial

      * 10-30 10:47:22.470 E/SELinux (560): avc:  denied  { find } for pid=1236 uid=1013 name=package_native scontext=u:r:mediaserver:s0 tcontext=u:object_r:package_native_service:s0 tclass=service_manager permissive=0

Signed-off-by: chrisw444 <wandersonrodriguesf1@gmail.com>
Change-Id: Ie7e7be168f35388a60d831fcb7b37e9ec39e9753